### PR TITLE
mlx 문제 관련 free 변경

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: sarchoi <sarchoi@student.42seoul.kr>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/02/28 19:18:15 by sarchoi           #+#    #+#              #
-#    Updated: 2022/08/26 23:49:40 by sarchoi          ###   ########seoul.kr   #
+#    Updated: 2022/08/29 14:53:50 by sarchoi          ###   ########seoul.kr   #
 #                                                                              #
 # **************************************************************************** #
 
@@ -49,7 +49,7 @@ SRCS = $(addprefix ./src/, $(SRCS_ROOT)) \
 OBJS = $(SRCS:.c=.o)
 
 MLX = minilibx
-MLX_FLAGS = -L libs/minilibx -lmlx
+MLX_FLAGS = -L libs/minilibx -lmlx -framework OpenGl -framework AppKit
 
 LIBFT = libft
 LIBFT_FLAGS = -L libs/libft -lft
@@ -77,11 +77,9 @@ $(NAME): $(OBJS) $(OBJS_GNL) $(OBJS_MANDATORY)
 
 $(LIBFT):
 	@make all bonus --silent --directory=libs/$(LIBFT)
-	$(info $(green)<MAKE>	Libft - make all bonus$(reset))
 
 $(MLX):
 	@make --silent --directory=libs/$(MLX)
-	$(info $(green)<MAKE>	MinilibX - make$(reset))
 
 clean:
 	@make clean --directory=libs/$(LIBFT)
@@ -96,6 +94,7 @@ fclean: clean
 	$(info $(green)<MAKE> Libft - fclean$(reset))
 	rm -f $(NAME)
 	rm -rf $(NAME).dSYM
+	rm -rf libs/minilibx/*.swiftsourceinfo
 	$(info $(green)<MAKE> fclean$(reset))
 
 re: fclean all

--- a/maps/micro.cub
+++ b/maps/micro.cub
@@ -1,0 +1,13 @@
+NO ./textures/north.png
+SO ./textures/south.png
+WE ./textures/west.png
+EA ./textures/east.png
+
+C 225,30,0
+F 220,100,0
+
+11111
+10001
+10N01
+10001
+11111

--- a/src/utils/exit.c
+++ b/src/utils/exit.c
@@ -6,7 +6,7 @@
 /*   By: sarchoi <sarchoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/26 21:43:59 by sarchoi           #+#    #+#             */
-/*   Updated: 2022/08/28 17:10:39 by sarchoi          ###   ########seoul.kr  */
+/*   Updated: 2022/08/29 15:00:28 by sarchoi          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,6 +56,9 @@ void	free_game_textures()
 	free_mlx_image(game->map.textures.minimap_wall);
 }
 
+/*
+** NOTE: Do not free `game->mlx` because mlx library does not provide function to free it. And `free()` is not stable.
+*/
 void	free_game()
 {
 	t_game	*game;
@@ -65,10 +68,7 @@ void	free_game()
 	free_game_textures();
 	free_mlx_image(game->minimap);
 	free_mlx_image(game->screen);
-	if (game->win)
-		mlx_destroy_window(game->mlx, game->win);
-	if (game->mlx)
-		free(game->mlx);
+	mlx_destroy_window(game->mlx, game->win);
 }
 
 void	exit_with_error(char *message)
@@ -84,8 +84,8 @@ void	exit_with_error(char *message)
 int	exit_with_close_button(void)
 {
 	free_game();
-	system("leaks cub3d");
 	printf("<info> Bye!\n");
+	system("leaks cub3d");
 	exit(EXIT_SUCCESS);
 	return (0);
 }


### PR DESCRIPTION
- #55
  - `mlx_init()`로 동적할당한 내용은 복잡한 구조체이기 때문에 `free()`를 써서 free하면 불안정함
  - `mlx_destroy_window()` 같은 전용 함수를 써야 베스트지만, mlx 라이브러리에서 제공하지 않음
- Makefile
  - library info 출력 삭제
  - mlx framework 관련 옵션 추가(없어도 작동했으나, 클러스터 환경에 대비하여 추가) 
  - make fclean에 `swiftsourceinfo` 파일 삭제 명령어 추가